### PR TITLE
add optional timeout for activities

### DIFF
--- a/src/app/modules/user-activity/user-activity.service.spec.ts
+++ b/src/app/modules/user-activity/user-activity.service.spec.ts
@@ -326,20 +326,25 @@ describe('UserActivityService', () => {
       it('should allow multiple activities with a timeout for the same element',
       fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
         // given
+        const slightlyAfterFirstPoll_Secs = UserActivityService.POLLING_INTERVAL_MS * 0.0012;
+        const aBitBeforeSecondPoll_Secs = UserActivityService.POLLING_INTERVAL_MS * 0.0018;
+        const beforeFirstPollAndTimeout_Millis = UserActivityService.POLLING_INTERVAL_MS * 0.3;
+        const timeOfSecondPoll = UserActivityService.POLLING_INTERVAL_MS * 2;
+
         const firstEvent = 'first.event';
         const secondEvent = 'second.event';
         const userActivityEvents = [
-           { name: firstEvent, active: true, activityType: 'aType', elementKey: 'path', timeout: 6 },
-           { name: secondEvent, active: true, activityType: 'aSecondType', elementKey: 'path', timeout: 9 },
+           { name: firstEvent, active: true, activityType: 'aType', elementKey: 'path', timeout: slightlyAfterFirstPoll_Secs},
+           { name: secondEvent, active: true, activityType: 'aSecondType', elementKey: 'path', timeout: aBitBeforeSecondPoll_Secs },
           ];
         service.start(...userActivityEvents);
         tick();
 
         // when
         messageBus.publish(firstEvent, { path: '/path/to/workspace/element.ext' });
-        tick(1500);
+        tick(beforeFirstPollAndTimeout_Millis);
         messageBus.publish(secondEvent, { path: '/path/to/workspace/element.ext' });
-        tick(10000);
+        tick(timeOfSecondPoll);
 
         // then
         const requests = httpTestingController.match({ method: 'POST', url: `${dummyUrl}/user-activity` });


### PR DESCRIPTION
This allows clients to register activities with a timeout: these do not have to be turned off, explicitly, but will instead become inactive after the given period of time has passed.
Meant to be used for persistent actions (e.g. saving a file), rather than ongoing activities.