### PR TITLE
Feature/transitions

### DIFF
--- a/src/app/modules/user-activity/user-activity.service.spec.ts
+++ b/src/app/modules/user-activity/user-activity.service.spec.ts
@@ -428,18 +428,18 @@ describe('UserActivityService', () => {
     it('should deactivate activity associated with a group when the group is deactiviated',
     fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
       // given
-      const event1 = 'user.activity.event1';
+      const event = 'user.activity.event1';
       const type = 'user.activity.type1';
-      const event2 = 'user.activity.event2';
+      const groupDeactivationEvent = 'user.activity.event2';
       const uaGroup = 'user.activity.group';
-      const userActivityEvent1: UserActivityEvent = { name: event1, active: true, activityType: type, elementKey: 'path', group: uaGroup };
-      const userActivityEvent2: UserActivityEvent = { name: event2, active: false, activityType: uaGroup, elementKey: 'path'};
-      service.start(userActivityEvent1, userActivityEvent2);
+      const userActivityEvent = { name: event, active: true, activityType: type, elementKey: 'path', group: uaGroup };
+      const groupDeactivationEventDefinition = { name: groupDeactivationEvent, active: false, activityType: uaGroup, elementKey: 'path'};
+      service.start(userActivityEvent, groupDeactivationEventDefinition);
 
       // when
-      messageBus.publish(event1, { path: '/path/to/workspace/element.ext' });
+      messageBus.publish(event, { path: '/path/to/workspace/element.ext' });
       tick();
-      messageBus.publish(event2, { path: '/path/to/workspace/element.ext' });
+      messageBus.publish(groupDeactivationEvent, { path: '/path/to/workspace/element.ext' });
       tick();
 
       // then

--- a/src/app/modules/user-activity/user-activity.service.spec.ts
+++ b/src/app/modules/user-activity/user-activity.service.spec.ts
@@ -72,7 +72,7 @@ describe('UserActivityService', () => {
       service.stop();
     })));
 
-    it('should evaluate active state dynamically when a callback was provided',
+  it('should evaluate active state dynamically when a callback was provided',
     fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
       // given
       const eventName = 'user.activity.event';
@@ -129,7 +129,7 @@ describe('UserActivityService', () => {
       service.stop();
     })));
 
-    it('should remove previously recorded activity when a corresponding user activity event is received (active=false)',
+  it('should remove previously recorded activity when a corresponding user activity event is received (active=false)',
     fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
       // given
       const activityEvent = 'activity.signal';
@@ -138,7 +138,8 @@ describe('UserActivityService', () => {
       const userActivityEvent: UserActivityEvent = { name: activityEvent, active: true, activityType: 'aType', elementKey: 'path' };
       const userInactivityEvent: UserActivityEvent = { name: inactivityEvent, active: false, activityType: 'aType', elementKey: 'path' };
       const differentUserActivityEvent: UserActivityEvent = {
-        name: differentEvent, active: true, activityType: 'anotherType', elementKey: 'path' };
+        name: differentEvent, active: true, activityType: 'anotherType', elementKey: 'path'
+      };
       service.start(userActivityEvent, userInactivityEvent, differentUserActivityEvent);
 
       // when
@@ -220,7 +221,7 @@ describe('UserActivityService', () => {
     })));
 
 
-    it('should publish activities of collaborating users on the message bus when receiving update from server',
+  it('should publish activities of collaborating users on the message bus when receiving update from server',
     fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
       // given
       let actualPayload: ElementActivity[];
@@ -228,9 +229,9 @@ describe('UserActivityService', () => {
       const serverUpdate: ElementActivity[] = [{
         element: '/path/to/file/collaborator/worksOn.ext',
         activities: [
-          { user: 'John Doe', type: 'openedFile'},
-          { user: 'John Doe', type: 'typesIntoFile'},
-          { user: 'Jane Doe', type: 'deletedElement'}]
+          { user: 'John Doe', type: 'openedFile' },
+          { user: 'John Doe', type: 'typesIntoFile' },
+          { user: 'Jane Doe', type: 'deletedElement' }]
       }];
       const userActivityEvent: UserActivityEvent = { name: 'some.event', active: true, activityType: 'sampleType', elementKey: 'path' };
       service.start(userActivityEvent);
@@ -249,7 +250,7 @@ describe('UserActivityService', () => {
       service.stop();
     })));
 
-    it('should send one final request with an empty list of activities to the server when being stopped',
+  it('should send one final request with an empty list of activities to the server when being stopped',
     fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
       // given
       const eventName = 'user.activity.event';
@@ -280,7 +281,7 @@ describe('UserActivityService', () => {
       expect(signOffRequest.request.body).toEqual([]);
     })));
 
-    it('should remove previously recorded activity automatically when a timeout was given',
+  it('should remove previously recorded activity automatically when a timeout was given',
     fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
       // given
       const activityEvent = 'activity.signal';
@@ -313,7 +314,7 @@ describe('UserActivityService', () => {
       service.stop();
     })));
 
-    it('should reset the timer when receiving a second message bus event for an activity with a timeout within the interval',
+  it('should reset the timer when receiving a second message bus event for an activity with a timeout within the interval',
     fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
       // given
       const activityEvent = 'activity.signal';
@@ -350,48 +351,106 @@ describe('UserActivityService', () => {
 
       // cleanup
       service.stop();
-      })));
+    })));
 
-      it('should allow multiple activities with a timeout for the same element',
-      fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
-        // given
-        const slightlyAfterFirstPoll_Secs = UserActivityService.POLLING_INTERVAL_MS * 0.0012;
-        const aBitBeforeSecondPoll_Secs = UserActivityService.POLLING_INTERVAL_MS * 0.0018;
-        const beforeFirstPollAndTimeout_Millis = UserActivityService.POLLING_INTERVAL_MS * 0.3;
-        const timeOfSecondPoll = UserActivityService.POLLING_INTERVAL_MS * 2;
+  it('should allow multiple activities with a timeout for the same element',
+    fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
+      // given
+      const slightlyAfterFirstPoll_Secs = UserActivityService.POLLING_INTERVAL_MS * 0.0012;
+      const aBitBeforeSecondPoll_Secs = UserActivityService.POLLING_INTERVAL_MS * 0.0018;
+      const beforeFirstPollAndTimeout_Millis = UserActivityService.POLLING_INTERVAL_MS * 0.3;
+      const timeOfSecondPoll = UserActivityService.POLLING_INTERVAL_MS * 2;
 
-        const firstEvent = 'first.event';
-        const secondEvent = 'second.event';
-        const userActivityEvents = [
-           { name: firstEvent, active: true, activityType: 'aType', elementKey: 'path', timeout: slightlyAfterFirstPoll_Secs},
-           { name: secondEvent, active: true, activityType: 'aSecondType', elementKey: 'path', timeout: aBitBeforeSecondPoll_Secs },
-          ];
-        service.start(...userActivityEvents);
-        tick();
+      const firstEvent = 'first.event';
+      const secondEvent = 'second.event';
+      const userActivityEvents = [
+        { name: firstEvent, active: true, activityType: 'aType', elementKey: 'path', timeout: slightlyAfterFirstPoll_Secs },
+        { name: secondEvent, active: true, activityType: 'aSecondType', elementKey: 'path', timeout: aBitBeforeSecondPoll_Secs },
+      ];
+      service.start(...userActivityEvents);
+      tick();
 
-        // when
-        messageBus.publish(firstEvent, { path: '/path/to/workspace/element.ext' });
-        tick(beforeFirstPollAndTimeout_Millis);
-        messageBus.publish(secondEvent, { path: '/path/to/workspace/element.ext' });
-        tick(timeOfSecondPoll);
+      // when
+      messageBus.publish(firstEvent, { path: '/path/to/workspace/element.ext' });
+      tick(beforeFirstPollAndTimeout_Millis);
+      messageBus.publish(secondEvent, { path: '/path/to/workspace/element.ext' });
+      tick(timeOfSecondPoll);
 
-        // then
-        const requests = httpTestingController.match({ method: 'POST', url: `${dummyUrl}/user-activity` });
-        expect(requests.length).toEqual(5);
-        requests[0].flush('response'); //  0.0s: request sent right after 'start(…)'
-        requests[1].flush('response'); //  0.0s: request sent right after first message bus event (resetting polling interval)
-        requests[2].flush('response'); //  1.5s: request sent right after second message bus event (resetting polling interval)
-        requests[3].flush('response'); //  6.5s: periodic polling; 'aType' timed out 0.5s ago
-        requests[4].flush('response'); // 11.5s: periodic polling; 'aSecondType' timed out 0.5s ago
-        httpTestingController.verify();
-        expect((requests[0].request.body as Array<ElementActivity>).length).toEqual(0);
-        expect(requests[1].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: ['aType'] }]);
-        expect(requests[2].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: ['aType', 'aSecondType'] }]);
-        expect(requests[3].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: ['aSecondType'] }]);
-        expect((requests[4].request.body as Array<ElementActivity>).length).toEqual(0);
+      // then
+      const requests = httpTestingController.match({ method: 'POST', url: `${dummyUrl}/user-activity` });
+      expect(requests.length).toEqual(5);
+      requests[0].flush('response'); //  0.0s: request sent right after 'start(…)'
+      requests[1].flush('response'); //  0.0s: request sent right after first message bus event (resetting polling interval)
+      requests[2].flush('response'); //  1.5s: request sent right after second message bus event (resetting polling interval)
+      requests[3].flush('response'); //  6.5s: periodic polling; 'aType' timed out 0.5s ago
+      requests[4].flush('response'); // 11.5s: periodic polling; 'aSecondType' timed out 0.5s ago
+      httpTestingController.verify();
+      expect((requests[0].request.body as Array<ElementActivity>).length).toEqual(0);
+      expect(requests[1].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: ['aType'] }]);
+      expect(requests[2].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: ['aType', 'aSecondType'] }]);
+      expect(requests[3].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: ['aSecondType'] }]);
+      expect((requests[4].request.body as Array<ElementActivity>).length).toEqual(0);
 
-        // cleanup
-        service.stop();
-      })));
+      // cleanup
+      service.stop();
+    })));
+
+
+  it('should deactivate activity when another activity of the same group becomes active',
+    fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
+      // given
+      const event1 = 'user.activity.event1';
+      const type1 = 'user.activity.type1';
+      const type2 = 'user.activity.type2';
+      const event2 = 'user.activity.event2';
+      const uaGroup = 'user.activity.group';
+      const userActivityEvent1: UserActivityEvent = { name: event1, active: true, activityType: type1, elementKey: 'path', group: uaGroup };
+      const userActivityEvent2: UserActivityEvent = { name: event2, active: true, activityType: type2, elementKey: 'path', group: uaGroup };
+      service.start(userActivityEvent1, userActivityEvent2);
+
+      // when
+      messageBus.publish(event1, { path: '/path/to/workspace/element.ext' });
+      tick();
+      messageBus.publish(event2, { path: '/path/to/workspace/element.ext' });
+      tick();
+
+      // then
+      const request = httpTestingController.match({ method: 'POST', url: `${dummyUrl}/user-activity` });
+      request[0].flush('response'); request[1].flush('response');
+      httpTestingController.verify();
+      expect(request[0].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: [type1] }]);
+      expect(request[1].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: [type2] }]);
+
+      // cleanup
+      service.stop();
+    })));
+
+    it('should deactivate activity associated with a group when the group is deactiviated',
+    fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
+      // given
+      const event1 = 'user.activity.event1';
+      const type = 'user.activity.type1';
+      const event2 = 'user.activity.event2';
+      const uaGroup = 'user.activity.group';
+      const userActivityEvent1: UserActivityEvent = { name: event1, active: true, activityType: type, elementKey: 'path', group: uaGroup };
+      const userActivityEvent2: UserActivityEvent = { name: event2, active: false, activityType: uaGroup, elementKey: 'path'};
+      service.start(userActivityEvent1, userActivityEvent2);
+
+      // when
+      messageBus.publish(event1, { path: '/path/to/workspace/element.ext' });
+      tick();
+      messageBus.publish(event2, { path: '/path/to/workspace/element.ext' });
+      tick();
+
+      // then
+      const request = httpTestingController.match({ method: 'POST', url: `${dummyUrl}/user-activity` });
+      request[0].flush('response'); request[1].flush('response');
+      httpTestingController.verify();
+      expect(request[0].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: [type] }]);
+      expect(request[1].request.body).toEqual([]);
+
+      // cleanup
+      service.stop();
+    })));
 
 });

--- a/src/app/modules/user-activity/user-activity.service.spec.ts
+++ b/src/app/modules/user-activity/user-activity.service.spec.ts
@@ -453,4 +453,35 @@ describe('UserActivityService', () => {
       service.stop();
     })));
 
+    it('should swap activities according to given transitions',
+    fakeAsync(inject([UserActivityService, MessagingService], (service: UserActivityService, messageBus: MessagingService) => {
+      // given
+      const event = 'user.activity.event1';
+      const type1 = 'user.activity.type1';
+      const type2 = 'user.activity.type2';
+      const transitions = [{to: type1}, {from: type1, to: type2}, {from: type2, to: type1}];
+      const userActivityEvent1: UserActivityEvent = { name: event, active: true, activityType: transitions, elementKey: 'path' };
+      service.start(userActivityEvent1);
+
+      // when
+      messageBus.publish(event, { path: '/path/to/workspace/element.ext' });
+      tick();
+      messageBus.publish(event, { path: '/path/to/workspace/element.ext' });
+      tick();
+      messageBus.publish(event, { path: '/path/to/workspace/element.ext' });
+      tick();
+
+      // then
+      const request = httpTestingController.match({ method: 'POST', url: `${dummyUrl}/user-activity` });
+      expect(request.length).toEqual(3);
+      request.forEach((req) => req.flush('response'));
+      httpTestingController.verify();
+      expect(request[0].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: [type1] }]);
+      expect(request[1].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: [type2] }]);
+      expect(request[2].request.body).toEqual([{ element: '/path/to/workspace/element.ext', activities: [type1] }]);
+
+      // cleanup
+      service.stop();
+    })));
+
 });

--- a/src/app/modules/user-activity/user-activity.service.ts
+++ b/src/app/modules/user-activity/user-activity.service.ts
@@ -120,7 +120,9 @@ export class UserActivityService {
   private processUserActivityUpdate(update: UserActivityUpdate) {
     this.userActivityEvent.next();
     if (this.isTransitionArray(update.activityType)) {
-      this.fireTransition(update.activityType, update.elementId, update.group);
+      if (update.active) {
+        this.fireTransition(update.activityType, update.elementId, update.group);
+      }
     } else {
       this.updateUserActivity(update.elementId, update.activityType, update.active, update.group);
       if (update.timeout) {

--- a/src/app/modules/user-activity/user-activity.service.ts
+++ b/src/app/modules/user-activity/user-activity.service.ts
@@ -29,6 +29,8 @@ export interface UserActivityEvent {
    * Alternatively, activityType can be specified as an array of transition objects with `from` and `to` fields each referring to an
    * activity type. In that case, for each transition object, **iff** the `from`-activity is active, it will be deactivated, and the
    * `to`-activity will be activated, instead. Transitions, and all `from` and `to` activities, must be associated with a single group.
+   * A transition may leave the `from` property undefined: this transition can only fire, if **no** activity type in the given group is
+   * currently active.
    */
   activityType: string | { from?: string, to: string }[];
   /**
@@ -157,19 +159,19 @@ export class UserActivityService {
     const currentActivity = this.userActivityStates.get(elementId) ? this.userActivityStates.get(elementId).get(group) : undefined;
     const transition = transitions.find((t) => t.from === currentActivity);
     if (transition) {
-      this.addUserActivity(elementId, transition.to, group);
+      this.setUserGroupActivity(elementId, transition.to, group);
     }
   }
 
   private updateUserActivity(elementId: string, activityType: string, active: boolean, group?: string) {
     if (active) {
-      this.addUserActivity(elementId, activityType, group ? group : activityType);
+      this.setUserGroupActivity(elementId, activityType, group ? group : activityType);
     } else {
       this.removeUserActivity(elementId, activityType);
     }
   }
 
-  private addUserActivity(elementId: string, activityType: string, group: string) {
+  private setUserGroupActivity(elementId: string, activityType: string, group: string) {
     if (!this.userActivityStates.has(elementId)) {
       this.userActivityStates.set(elementId, new Map<string, string>());
     }

--- a/src/app/modules/user-activity/user-activity.service.ts
+++ b/src/app/modules/user-activity/user-activity.service.ts
@@ -153,6 +153,7 @@ export class UserActivityService {
       this.userActivityStates.set(elementId, new Map<string, string>());
     }
     this.userActivityStates.get(elementId).set(group, activityType);
+    console.log(`set user activity [${group}, ${activityType}] for "${elementId}"`);
   }
 
   private timeoutUserActivity(elementId: string, activityType: string, timeoutSecs: number) {
@@ -176,6 +177,7 @@ export class UserActivityService {
       if (activitySet.size === 0) {
         this.userActivityStates.delete(elementId);
       }
+      console.log(`deleted user activity ${activityType} of "${elementId}"`);
     }
     const timerKey = this.createTimeoutTimerKey(elementId, activityType);
     if (this.userActivityTimeoutTimers.has(timerKey)) {


### PR DESCRIPTION
* activity groups act like composite states (only one activity type in the group can be active)
* transitions allow finer control over when to change state within a group, based on the current activity type in that group
* for renaming, all user activities of an "old" element can be moved to a new one. The old element will then be associated with the given user activity (i.e. to indicate "this element has been renamed" or something)